### PR TITLE
Add volume to mysql to persist data after restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - "MOODLE_URL:http://localhost:8080"
   mysql:
     image: mysql:5
+    volumes:
+      - mysql_data:/var/lib/mysql
     environment:
       - MYSQL_DATABASE=moodle
       - MYSQL_ROOT_PASSWORD=moodle
@@ -18,3 +20,4 @@ services:
       - MYSQL_PASSWORD=moodle
 volumes:
   moodle_data:
+  mysql_data:


### PR DESCRIPTION
In the previous commit I forgot to add a volume to the mysql container. This means that stopping the containers would result in the database being lost, and you would have to re-install all over again.

This pull request should solve that issue.