### PR TITLE
change moodle_exit to exit for phpunit init script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ language: php
 php:
     # We only run the highest and lowest supported versions to reduce the load on travis-ci.org.
     - 7.2
-    - 7.0
+    - 7.1
 
 addons:
   postgresql: "9.6"

--- a/admin/tool/phpunit/cli/init.php
+++ b/admin/tool/phpunit/cli/init.php
@@ -56,23 +56,23 @@ if ($code == 0) {
 } else if ($code == PHPUNIT_EXITCODE_INSTALL) {
     passthru("php util.php --install", $code);
     if ($code != 0) {
-        moodle_exit($code);
+        exit($code);
     }
 
 } else if ($code == PHPUNIT_EXITCODE_REINSTALL) {
     passthru("php util.php --drop", $code);
     passthru("php util.php --install", $code);
     if ($code != 0) {
-        moodle_exit($code);
+        exit($code);
     }
 
 } else {
     echo implode("\n", $output)."\n";
-    moodle_exit($code);
+    exit($code);
 }
 
 passthru("php util.php --buildconfig", $code);
 
 echo "\n";
 echo "PHPUnit test environment setup complete.\n";
-moodle_exit(0);
+exit(0);


### PR DESCRIPTION
This should enable the travis build to go completely green.

It is unlikely we will need the testable exit for this script - being that it's job is to set up the test environment.

I also believe that we will want to remove this test infrastructure over time anyway.

> Note: I have also updated the .travis.yml to not run the php7.0 build - and instead run php7.1

This pr is for #12 