### PR TITLE
Update phpunit to include new test suite

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,4 +23,9 @@
          timeoutForMediumTests="10"
          timeoutForLargeTests="60"
          verbose="false">
+    <testsuites>
+        <testsuite name="BetterMood tests">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
 </phpunit>


### PR DESCRIPTION
Pretty self explanatory. I have added the new tests people have been creating to the `phpunit.dist.xml` file.

In order to run the tests you simply need to run `./vendor/bin/phpunit` and all should be good.

None of the old/current moodle tests are running via this method. It seems that some further tweaking will be required for those.