### PR TITLE
require UriScheme classes directly in weblib.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,6 @@
     "type": "project",
     "homepage": "https://moodle.org",
     "autoload": {
-        "files": [
-            "lib/htmlpurifier/URIScheme/Gopher.php",
-            "lib/htmlpurifier/URIScheme/Irc.php",
-            "lib/htmlpurifier/URIScheme/Mms.php",
-            "lib/htmlpurifier/URIScheme/Rtmp.php",
-            "lib/htmlpurifier/URIScheme/Rtsp.php",
-            "lib/htmlpurifier/URIScheme/Teamspeak.php"
-        ],
         "psr-4": {
             "Moodle\\": "src"
         }

--- a/lib/weblib.php
+++ b/lib/weblib.php
@@ -1793,6 +1793,14 @@ function purify_html($text, $options = array()) {
     }
 
     if (empty($purifiers[$type])) {
+
+        require $CFG->libdir . '/htmlpurifier/UriScheme/Gopher.php';
+        require $CFG->libdir . '/htmlpurifier/UriScheme/Irc.php';
+        require $CFG->libdir . '/htmlpurifier/UriScheme/Mms.php';
+        require $CFG->libdir . '/htmlpurifier/UriScheme/Rtmp.php';
+        require $CFG->libdir . '/htmlpurifier/UriScheme/Rtsp.php';
+        require $CFG->libdir . '/htmlpurifier/UriScheme/Teamspeak.php';
+
         $config = HTMLPurifier_Config::createDefault();
 
         $config->set('HTML.DefinitionID', 'moodlehtml');

--- a/lib/weblib.php
+++ b/lib/weblib.php
@@ -1793,13 +1793,12 @@ function purify_html($text, $options = array()) {
     }
 
     if (empty($purifiers[$type])) {
-
-        require $CFG->libdir . '/htmlpurifier/UriScheme/Gopher.php';
-        require $CFG->libdir . '/htmlpurifier/UriScheme/Irc.php';
-        require $CFG->libdir . '/htmlpurifier/UriScheme/Mms.php';
-        require $CFG->libdir . '/htmlpurifier/UriScheme/Rtmp.php';
-        require $CFG->libdir . '/htmlpurifier/UriScheme/Rtsp.php';
-        require $CFG->libdir . '/htmlpurifier/UriScheme/Teamspeak.php';
+        require $CFG->libdir . '/htmlpurifier/URIScheme/Gopher.php';
+        require $CFG->libdir . '/htmlpurifier/URIScheme/Irc.php';
+        require $CFG->libdir . '/htmlpurifier/URIScheme/Mms.php';
+        require $CFG->libdir . '/htmlpurifier/URIScheme/Rtmp.php';
+        require $CFG->libdir . '/htmlpurifier/URIScheme/Rtsp.php';
+        require $CFG->libdir . '/htmlpurifier/URIScheme/Teamspeak.php';
 
         $config = HTMLPurifier_Config::createDefault();
 


### PR DESCRIPTION
As discussed in #53 reference the classes directly in weblib without the use of composers autoloader