### PR TITLE
Removed old-style constructors.

### DIFF
--- a/auth/email/auth.php
+++ b/auth/email/auth.php
@@ -40,16 +40,6 @@ class auth_plugin_email extends auth_plugin_base {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function auth_plugin_email() {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct();
-    }
-
-    /**
      * Returns true if the username and password work and false if they are
      * wrong or don't exist.
      *

--- a/auth/ldap/auth.php
+++ b/auth/ldap/auth.php
@@ -128,16 +128,6 @@ class auth_plugin_ldap extends auth_plugin_base {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function auth_plugin_ldap() {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct();
-    }
-
-    /**
      * Returns true if the username and password work and false if they are
      * wrong or don't exist.
      *

--- a/auth/manual/auth.php
+++ b/auth/manual/auth.php
@@ -54,16 +54,6 @@ class auth_plugin_manual extends auth_plugin_base {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function auth_plugin_manual() {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct();
-    }
-
-    /**
      * Returns true if the username and password work and false if they are
      * wrong or don't exist. (Non-mnet accounts only!)
      *

--- a/auth/mnet/auth.php
+++ b/auth/mnet/auth.php
@@ -42,16 +42,6 @@ class auth_plugin_mnet extends auth_plugin_base {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function auth_plugin_mnet() {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct();
-    }
-
-    /**
      * This function is normally used to determine if the username and password
      * are correct for local logins. Always returns false, as local users do not
      * need to login over mnet xmlrpc.

--- a/auth/shibboleth/auth.php
+++ b/auth/shibboleth/auth.php
@@ -44,16 +44,6 @@ class auth_plugin_shibboleth extends auth_plugin_base {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function auth_plugin_shibboleth() {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct();
-    }
-
-    /**
      * Returns true if the username and password work and false if they are
      * wrong or don't exist.
      *

--- a/grade/export/lib.php
+++ b/grade/export/lib.php
@@ -630,16 +630,6 @@ class grade_export_update_buffer {
         $this->export_time = time();
     }
 
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function grade_export_update_buffer() {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct();
-    }
-
     public function flush($buffersize) {
         global $CFG, $DB;
 

--- a/grade/grading/form/guide/guideeditor.php
+++ b/grade/grading/form/guide/guideeditor.php
@@ -58,16 +58,6 @@ class moodlequickform_guideeditor extends HTML_QuickForm_input {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function moodlequickform_guideeditor($elementname=null, $elementlabel=null, $attributes=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementname, $elementlabel, $attributes);
-    }
-
-    /**
      * get html for help button
      *
      * @return  string html for help button

--- a/grade/lib.php
+++ b/grade/lib.php
@@ -1126,16 +1126,6 @@ class grade_plugin_return {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function grade_plugin_return($params = null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($params);
-    }
-
-    /**
      * Returns return parameters as options array suitable for buttons.
      * @return array options
      */
@@ -2094,16 +2084,6 @@ class grade_seq extends grade_structure {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function grade_seq($courseid, $category_grade_last=false, $nooutcomes=false) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($courseid, $category_grade_last, $nooutcomes);
-    }
-
-    /**
      * Static recursive helper - makes the grade_item for category the last children
      *
      * @param array &$element The seed of the recursion
@@ -2286,17 +2266,6 @@ class grade_tree extends grade_structure {
 
         grade_tree::fill_levels($this->levels, $this->top_element, 0);
 
-    }
-
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function grade_tree($courseid, $fillers=true, $category_grade_last=false,
-                               $collapsed=null, $nooutcomes=false) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($courseid, $fillers, $category_grade_last, $collapsed, $nooutcomes);
     }
 
     /**

--- a/lib/editor/tinymce/plugins/spellchecker/classes/SpellChecker.php
+++ b/lib/editor/tinymce/plugins/spellchecker/classes/SpellChecker.php
@@ -4,7 +4,7 @@
  *
  * @package MCManager.includes
  * @author Moxiecode
- * @copyright Copyright © 2004-2007, Moxiecode Systems AB, All rights reserved.
+ * @copyright Copyright ï¿½ 2004-2007, Moxiecode Systems AB, All rights reserved.
  */
 
 class SpellChecker {
@@ -16,16 +16,6 @@ class SpellChecker {
 	public function __construct(&$config) {
 		$this->_config = $config;
 	}
-
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function SpellChecker(&$config) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($config);
-    }
 
 	/**
 	 * Simple loopback function everything that gets in will be send back.

--- a/lib/editor/tinymce/plugins/spellchecker/classes/utils/JSON.php
+++ b/lib/editor/tinymce/plugins/spellchecker/classes/utils/JSON.php
@@ -4,7 +4,7 @@
  *
  * @package MCManager.utils
  * @author Moxiecode
- * @copyright Copyright © 2007, Moxiecode Systems AB, All rights reserved.
+ * @copyright Copyright ï¿½ 2007, Moxiecode Systems AB, All rights reserved.
  */
 
 define('JSON_BOOL', 1);
@@ -37,16 +37,6 @@ class Moxiecode_JSONReader {
 		$this->_lastLocations = array();
 		$this->_needProp = false;
 	}
-
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function Moxiecode_JSONReader($data) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($data);
-    }
 
 	function getToken() {
 		return $this->_token;
@@ -372,16 +362,6 @@ class Moxiecode_JSONReader {
 class Moxiecode_JSON {
 	public function __construct() {
 	}
-
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function Moxiecode_JSON() {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct();
-    }
 
 	function decode($input) {
 		$reader = new Moxiecode_JSONReader($input);

--- a/lib/environmentlib.php
+++ b/lib/environmentlib.php
@@ -1274,16 +1274,6 @@ class environment_results {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function environment_results($part) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($part);
-    }
-
-    /**
      * Set the status
      *
      * @param bool $testpassed true means the test passed and all is OK. false means it failed.

--- a/lib/evalmath/evalmath.class.php
+++ b/lib/evalmath/evalmath.class.php
@@ -125,16 +125,6 @@ class EvalMath {
         $this->allowimplicitmultiplication = $allowimplicitmultiplication;
     }
 
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function EvalMath($allowconstants = false, $allowimplicitmultiplication = false) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($allowconstants, $allowimplicitmultiplication);
-    }
-
     function e($expr) {
         return $this->evaluate($expr);
     }

--- a/lib/form/autocomplete.php
+++ b/lib/form/autocomplete.php
@@ -107,16 +107,6 @@ class MoodleQuickForm_autocomplete extends MoodleQuickForm_select {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_autocomplete($elementName=null, $elementLabel=null, $options=null, $attributes=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $options, $attributes);
-    }
-
-    /**
      * Returns HTML for select form element.
      *
      * @return string

--- a/lib/form/button.php
+++ b/lib/form/button.php
@@ -59,16 +59,6 @@ class MoodleQuickForm_button extends HTML_QuickForm_button implements templatabl
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_button($elementName=null, $value=null, $attributes=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $value, $attributes);
-    }
-
-    /**
      * get html for help button
      *
      * @return string html for help button

--- a/lib/form/dateselector.php
+++ b/lib/form/dateselector.php
@@ -105,16 +105,6 @@ class MoodleQuickForm_date_selector extends MoodleQuickForm_group {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_date_selector($elementName = null, $elementLabel = null, $options = array(), $attributes = null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $options, $attributes);
-    }
-
-    /**
      * This will create date group element constisting of day, month and year.
      *
      * @access private

--- a/lib/form/editor.php
+++ b/lib/form/editor.php
@@ -103,16 +103,6 @@ class MoodleQuickForm_editor extends HTML_QuickForm_element implements templatab
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_editor($elementName=null, $elementLabel=null, $attributes=null, $options=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $attributes, $options);
-    }
-
-    /**
      * Called by HTML_QuickForm whenever form event is made on this element
      *
      * @param string $event Name of event

--- a/lib/form/htmleditor.php
+++ b/lib/form/htmleditor.php
@@ -74,16 +74,6 @@ class MoodleQuickForm_htmleditor extends MoodleQuickForm_textarea{
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_htmleditor($elementName=null, $elementLabel=null, $options=array(), $attributes=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $options, $attributes);
-    }
-
-    /**
      * Returns the input field in HTML
      *
      * @return string

--- a/lib/form/listing.php
+++ b/lib/form/listing.php
@@ -93,16 +93,6 @@ class MoodleQuickForm_listing extends HTML_QuickForm_input {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_listing($elementName=null, $elementLabel=null, $attributes=null, $options=array()) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $attributes, $options);
-    }
-
-    /**
      * Returns HTML for listing form element.
      *
      * @return string the HTML.

--- a/lib/form/modgrade.php
+++ b/lib/form/modgrade.php
@@ -120,16 +120,6 @@ class MoodleQuickForm_modgrade extends MoodleQuickForm_group {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_modgrade($elementname = null, $elementlabel = null, $options = array(), $attributes = null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementname, $elementlabel, $options, $attributes);
-    }
-
-    /**
      * Create elements for this group.
      */
     public function _createElements() {

--- a/lib/form/modvisible.php
+++ b/lib/form/modvisible.php
@@ -63,16 +63,6 @@ class MoodleQuickForm_modvisible extends MoodleQuickForm_select{
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_modvisible($elementName=null, $elementLabel=null, $attributes=null, $options=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $attributes, $options);
-    }
-
-    /**
      * Called by HTML_QuickForm whenever form event is made on this element
      *
      * @param string $event Name of event

--- a/lib/form/questioncategory.php
+++ b/lib/form/questioncategory.php
@@ -63,14 +63,4 @@ class MoodleQuickForm_questioncategory extends MoodleQuickForm_selectgroups {
                                                 false, $this->_options['nochildrenof']));
         }
     }
-
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_questioncategory($elementName = null, $elementLabel = null, $options = null, $attributes = null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $options, $attributes);
-    }
 }

--- a/lib/form/selectwithlink.php
+++ b/lib/form/selectwithlink.php
@@ -84,16 +84,6 @@ class MoodleQuickForm_selectwithlink extends HTML_QuickForm_select implements te
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_selectwithlink($elementName=null, $elementLabel=null, $options=null, $attributes=null, $linkdata=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $options, $attributes, $linkdata);
-    }
-
-    /**
      * Sets label to be hidden
      *
      * @param bool $hiddenLabel sets if label should be hidden

--- a/lib/form/static.php
+++ b/lib/form/static.php
@@ -61,16 +61,6 @@ class MoodleQuickForm_static extends HTML_QuickForm_static implements templatabl
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_static($elementName=null, $elementLabel=null, $text=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $text);
-    }
-
-    /**
      * get html for help button
      *
      * @return string html for help button

--- a/lib/form/tags.php
+++ b/lib/form/tags.php
@@ -155,16 +155,6 @@ class MoodleQuickForm_tags extends MoodleQuickForm_autocomplete {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_tags($elementName = null, $elementLabel = null, $options = array(), $attributes = null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $options, $attributes);
-    }
-
-    /**
      * Finds the tag collection to use for standard tag selector
      *
      * @return int

--- a/lib/form/warning.php
+++ b/lib/form/warning.php
@@ -68,16 +68,6 @@ class MoodleQuickForm_warning extends HTML_QuickForm_static implements templatab
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function MoodleQuickForm_warning($elementName=null, $elementClass='notifyproblem', $text=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementClass, $text);
-    }
-
-    /**
      * Returns HTML for this form element.
      *
      * @return string

--- a/lib/graphlib.php
+++ b/lib/graphlib.php
@@ -1191,16 +1191,6 @@ class graph {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function graph() {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct();
-    }
-
-    /**
      * Prepare label's text for GD output.
      *
      * @param string    $label string to be prepared.

--- a/lib/mathslib.php
+++ b/lib/mathslib.php
@@ -71,16 +71,6 @@ class calc_formula {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function calc_formula($formula, $params=false) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($formula, $params);
-    }
-
-    /**
      * Raplace parameters used in existing formula,
      * parameter names must contain only lowercase [a-z] letters, no other characters are allowed!
      *

--- a/lib/pear/HTML/Common.php
+++ b/lib/pear/HTML/Common.php
@@ -89,16 +89,6 @@ class HTML_Common {
         $this->setTabOffset($tabOffset);
     } // end constructor
 
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_Common($attributes = null, $tabOffset = 0) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($attributes, $tabOffset);
-    }
-
     public static function raiseError($message = null,
                                        $code = null,
                                        $mode = null,

--- a/lib/pear/HTML/QuickForm.php
+++ b/lib/pear/HTML/QuickForm.php
@@ -301,16 +301,6 @@ class HTML_QuickForm extends HTML_Common {
         }
     } // end constructor
 
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm($formName='', $method='post', $action='', $target='', $attributes=null, $trackSubmit = false) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($formName, $method, $action, $target, $attributes, $trackSubmit);
-    }
-
     // }}}
     // {{{ apiVersion()
 
@@ -2003,18 +1993,5 @@ class HTML_QuickForm_Error extends PEAR_Error {
             parent::__construct("Invalid error code: $code", QUICKFORM_ERROR, $mode, $level, $debuginfo);
         }
     }
-
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm_Error($code = QUICKFORM_ERROR, $mode = PEAR_ERROR_RETURN,
-                         $level = E_USER_NOTICE, $debuginfo = null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($code, $mode, $level, $debuginfo);
-    }
-
-    // }}}
 } // end class HTML_QuickForm_Error
 ?>

--- a/lib/pear/HTML/QuickForm/advcheckbox.php
+++ b/lib/pear/HTML/QuickForm/advcheckbox.php
@@ -82,16 +82,6 @@ class HTML_QuickForm_advcheckbox extends HTML_QuickForm_checkbox
         $this->setValues($values);
     } //end constructor
 
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm_advcheckbox($elementName=null, $elementLabel=null, $text=null, $attributes=null, $values=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $text, $attributes, $values);
-    }
-
     // }}}
     // {{{ getPrivateName()
 

--- a/lib/pear/HTML/QuickForm/autocomplete.php
+++ b/lib/pear/HTML/QuickForm/autocomplete.php
@@ -84,16 +84,6 @@ class HTML_QuickForm_autocomplete extends HTML_QuickForm_text
         }
     } //end constructor
 
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm_autocomplete($elementName = null, $elementLabel = null, $options = null, $attributes = null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $options, $attributes);
-    }
-
     // }}}
     // {{{ setOptions()
 

--- a/lib/pear/HTML/QuickForm/hiddenselect.php
+++ b/lib/pear/HTML/QuickForm/hiddenselect.php
@@ -60,19 +60,6 @@ class HTML_QuickForm_hiddenselect extends HTML_QuickForm_select
     } //end constructor
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm_hiddenselect($elementName=null, $elementLabel=null, $options=null, $attributes=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $options, $attributes);
-    }
-
-    // }}}
-    // {{{ toHtml()
-
-    /**
      * Returns the SELECT in HTML
      *
      * @since     1.0

--- a/lib/pear/HTML/QuickForm/hierselect.php
+++ b/lib/pear/HTML/QuickForm/hierselect.php
@@ -126,19 +126,6 @@ class HTML_QuickForm_hierselect extends HTML_QuickForm_group
     } //end constructor
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm_hierselect($elementName=null, $elementLabel=null, $attributes=null, $separator=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $attributes, $separator);
-    }
-
-    // }}}
-    // {{{ setOptions()
-
-    /**
      * Initialize the array structure containing the options for each select element.
      * Call the functions that actually do the magic.
      *

--- a/lib/pear/HTML/QuickForm/image.php
+++ b/lib/pear/HTML/QuickForm/image.php
@@ -50,16 +50,6 @@ class HTML_QuickForm_image extends HTML_QuickForm_input
         $this->setSource($src);
     } // end class constructor
 
-    /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm_image($elementName=null, $src='', $attributes=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $src, $attributes);
-    }
-
     // }}}
     // {{{ setSource()
 

--- a/lib/pear/HTML/QuickForm/input.php
+++ b/lib/pear/HTML/QuickForm/input.php
@@ -50,19 +50,6 @@ class HTML_QuickForm_input extends HTML_QuickForm_element
     } //end constructor
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm_input($elementName=null, $elementLabel=null, $attributes=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $attributes);
-    }
-
-    // }}}
-    // {{{ setType()
-
-    /**
      * Sets the element type
      *
      * @param     string    $type   Element type

--- a/lib/pear/HTML/QuickForm/password.php
+++ b/lib/pear/HTML/QuickForm/password.php
@@ -52,19 +52,6 @@ class HTML_QuickForm_password extends HTML_QuickForm_input
     } //end constructor
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm_password($elementName=null, $elementLabel=null, $attributes=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $attributes);
-    }
-    
-    // }}}
-    // {{{ setSize()
-
-    /**
      * Sets size of password element
      * 
      * @param     string    $size  Size of password field

--- a/lib/pear/HTML/QuickForm/reset.php
+++ b/lib/pear/HTML/QuickForm/reset.php
@@ -52,19 +52,6 @@ class HTML_QuickForm_reset extends HTML_QuickForm_input
     } //end constructor
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm_reset($elementName=null, $value=null, $attributes=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $value, $attributes);
-    }
-
-    // }}}
-    // {{{ freeze()
-
-    /**
      * Freeze the element so that only its value is returned
      * 
      * @access    public

--- a/lib/pear/HTML/QuickForm/text.php
+++ b/lib/pear/HTML/QuickForm/text.php
@@ -53,19 +53,6 @@ class HTML_QuickForm_text extends HTML_QuickForm_input
     } //end constructor
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function HTML_QuickForm_text($elementName=null, $elementLabel=null, $attributes=null) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($elementName, $elementLabel, $attributes);
-    }
-        
-    // }}}
-    // {{{ setSize()
-
-    /**
      * Sets size of text field
      * 
      * @param     string    $size  Size of text field

--- a/lib/searchlib.php
+++ b/lib/searchlib.php
@@ -57,16 +57,6 @@ class search_token {
 
   }
 
-  /**
-   * Old syntax of class constructor. Deprecated in PHP7.
-   *
-   * @deprecated since Moodle 3.1
-   */
-  public function search_token($type, $value) {
-    debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-    self::__construct($type, $value);
-  }
-
   // Try to clean up user input to avoid potential security issues.
   // Need to think about this some more.
 
@@ -212,17 +202,6 @@ class search_lexer extends Lexer{
     $this->addExitPattern("\s","plainstring");
 
   }
-
-  /**
-   * Old syntax of class constructor. Deprecated in PHP7.
-   *
-   * @deprecated since Moodle 3.1
-   */
-  public function search_lexer(&$parser) {
-    debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-    self::__construct($parser);
-  }
-
 }
 
 

--- a/mnet/xmlrpc/xmlparser.php
+++ b/mnet/xmlrpc/xmlparser.php
@@ -22,16 +22,6 @@ class mnet_encxml_parser {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function mnet_encxml_parser() {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct();
-    }
-
-    /**
      * Set default element handlers and initialise properties to empty.
      *
      * @return bool True

--- a/mod/wiki/diff/diff_nwiki.php
+++ b/mod/wiki/diff/diff_nwiki.php
@@ -507,16 +507,6 @@ class WikiDiff
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function WikiDiff($from_lines, $to_lines) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($from_lines, $to_lines);
-    }
-
-    /**
      * Compute reversed WikiDiff.
      *
      * SYNOPSIS:

--- a/question/category_class.php
+++ b/question/category_class.php
@@ -207,16 +207,6 @@ class question_category_object {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function question_category_object($page, $pageurl, $contexts, $currentcat, $defaultcategory, $todelete, $addcontexts) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($page, $pageurl, $contexts, $currentcat, $defaultcategory, $todelete, $addcontexts);
-    }
-
-    /**
      * Initializes this classes general category-related variables
      */
     public function initialize($page, $contexts, $currentcat, $defaultcategory, $todelete, $addcontexts) {

--- a/user/filters/courserole.php
+++ b/user/filters/courserole.php
@@ -42,16 +42,6 @@ class user_filter_courserole extends user_filter_type {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function user_filter_courserole($name, $label, $advanced) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($name, $label, $advanced);
-    }
-
-    /**
      * Returns an array of available roles
      * @return array of availble roles
      */

--- a/user/filters/yesno.php
+++ b/user/filters/yesno.php
@@ -42,16 +42,6 @@ class user_filter_yesno extends user_filter_simpleselect {
     }
 
     /**
-     * Old syntax of class constructor. Deprecated in PHP7.
-     *
-     * @deprecated since Moodle 3.1
-     */
-    public function user_filter_yesno($name, $label, $advanced, $field) {
-        debugging('Use of class name as constructor is deprecated', DEBUG_DEVELOPER);
-        self::__construct($name, $label, $advanced, $field);
-    }
-
-    /**
      * Returns the condition to be used with SQL
      *
      * @param array $data filter settings


### PR DESCRIPTION
I am not closing the originating ticket, since I probably haven’t removed all of the old constructors, but just the ones that had been explicitly marked as such. Anyway, this will greatly simplify my upcoming pull req dealing with the `debugging()` function.